### PR TITLE
yaml required in init_db.rb

### DIFF
--- a/init_db.rb
+++ b/init_db.rb
@@ -2,6 +2,7 @@ require 'pry' if $RACK_ENV == 'development'
 
 require 'active_record'
 require 'chronic'
+require 'yaml'
 
 puts "Loading DB config for environment: #{$RACK_ENV}..."
 if $RACK_ENV == 'production'


### PR DESCRIPTION
> init_db.rb:10:in `<top (required)>': uninitialized constant YAML (NameError)

bug fix
